### PR TITLE
Refactor: Use Tailwind CSS for SelectionActionBar theming

### DIFF
--- a/src/content/components/SelectionActionBar.tsx
+++ b/src/content/components/SelectionActionBar.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useRef } from 'react'; // Removed useEffect, useState
 import {
   PhotoIcon as ImgIcon,
   ArrowDownTrayIcon as DownloadIcon,
@@ -37,7 +37,7 @@ const ShadcnCircularActionButton: React.FC<{
 }> = ({ onClick, label, icon: Icon, disabled, title }) => (
   <div 
     className="flex flex-col items-center"
-    style={{ width: '5rem', flexShrink: 0 }}
+    // style={{ width: '5rem', flexShrink: 0 }} // width can be managed by container gap or min-w if needed
   >
     <Button
       variant="outline"
@@ -47,9 +47,10 @@ const ShadcnCircularActionButton: React.FC<{
       title={title || label}
       className="rounded-full w-12 h-12 p-0 mb-1 flex items-center justify-center data-[disabled]:opacity-50"
     >
-      <Icon className="h-6 w-6" />
+      <Icon className="h-6 w-6" /> 
     </Button>
-    <span className="text-xs text-center whitespace-nowrap">
+    {/* Action Button Labels: Apply text-muted-foreground */}
+    <span className="text-xs text-center whitespace-nowrap text-muted-foreground">
       {label}
     </span>
   </div>
@@ -66,121 +67,21 @@ const SelectionActionBar: React.FC<SelectionActionBarProps> = ({
   onClose,
 }) => {
   const actionBarRef = useRef<HTMLDivElement>(null);
-  const [currentThemeStyles, setCurrentThemeStyles] = useState({ 
-    backgroundColor: '#FFFFFF', 
-    color: '#202124', 
-    mutedColor: '#5F6368', 
-    borderColor: '#DADCE0' 
-  });
 
-  useEffect(() => {
-    const updateThemeStyles = () => {
-      if (actionBarRef.current) {
-        const docEl = document.documentElement;
-        const bodyStyle = window.getComputedStyle(document.body);
-        
-        // 使用更健壮的暗色模式检测逻辑
-        const isDarkMode = docEl.getAttribute('dark') === 'true' ||
-                           docEl.classList.contains('dark') ||
-                           (bodyStyle.backgroundColor && 
-                            parseInt(bodyStyle.backgroundColor.split('(')[1] || '0') < 128 && // Ensure there's a value before parseInt
-                            !bodyStyle.backgroundColor.includes('rgba(0, 0, 0, 0)') // Ensure not fully transparent
-                           );
-
-        const rootStyle = getComputedStyle(docEl);
-        const cardBg = rootStyle.getPropertyValue('--card').trim();
-        const cardFg = rootStyle.getPropertyValue('--card-foreground').trim();
-        const mutedFg = rootStyle.getPropertyValue('--muted-foreground').trim();
-        const border = rootStyle.getPropertyValue('--border').trim();
-
-        let newStyles = { 
-          backgroundColor: isDarkMode ? '#2D2E30' : '#FFFFFF',
-          color: isDarkMode ? '#E8EAED' : '#202124',
-          mutedColor: isDarkMode ? '#9AA0A6' : '#5F6368',
-          borderColor: isDarkMode ? '#5F6368' : '#DADCE0'
-        };
-
-        if (cardBg) newStyles.backgroundColor = cardBg;
-        if (cardFg) newStyles.color = cardFg;
-        if (mutedFg) newStyles.mutedColor = mutedFg;
-        if (border) newStyles.borderColor = border;
-        
-        setCurrentThemeStyles(newStyles);
-      }
-    };
-
-    updateThemeStyles();
-
-    const observer = new MutationObserver((mutationsList) => {
-      for (const mutation of mutationsList) {
-        if (mutation.type === 'attributes' && (mutation.attributeName === 'class' || mutation.attributeName === 'dark' || mutation.attributeName === 'style')) {
-          // Observe class, dark attribute on html, or style on body (for background color check)
-          updateThemeStyles();
-          break; // Found a relevant mutation, no need to check others
-        }
-      }
-    });
-    observer.observe(document.documentElement, { attributes: true, attributeFilter: ['class', 'dark'] });
-    observer.observe(document.body, { attributes: true, attributeFilter: ['style'] }); // For body background changes
-
-    return () => observer.disconnect();
-
-  }, []);
-
-  useEffect(() => {
-    // Apply dynamically determined styles
-    if (actionBarRef.current) {
-      actionBarRef.current.style.backgroundColor = currentThemeStyles.backgroundColor;
-      actionBarRef.current.style.color = currentThemeStyles.color;
-      
-      const labelElement = actionBarRef.current.querySelector(
-        'label[for="gemini-enhancer-select-all-checkbox-shadcn"]'
-      ) as HTMLLabelElement;
-      if (labelElement) {
-        labelElement.style.color = currentThemeStyles.color;
-        const countSpan = labelElement.querySelector('span');
-        if (countSpan) {
-          countSpan.style.color = currentThemeStyles.mutedColor;
-        }
-      }
-
-      const actionButtonLabels = actionBarRef.current.querySelectorAll('.flex.flex-col.items-center > span');
-      actionButtonLabels.forEach(span => {
-        (span as HTMLElement).style.color = currentThemeStyles.mutedColor;
-      });
-
-      const actionButtonIcons = actionBarRef.current.querySelectorAll('.flex.flex-col.items-center button svg');
-      actionButtonIcons.forEach(svgIcon => {
-        (svgIcon as HTMLElement).style.color = currentThemeStyles.color;
-      });
-      
-      const closeButtonIcon = actionBarRef.current.querySelector('button[title="关闭多选"] svg');
-      if (closeButtonIcon) {
-        (closeButtonIcon as HTMLElement).style.color = currentThemeStyles.color;
-      }
-
-      const separator = actionBarRef.current.querySelector('.border-l') as HTMLDivElement;
-      if (separator) {
-        separator.style.borderColor = currentThemeStyles.borderColor;
-      }
-    }
-  }, [currentThemeStyles]);
+  // Removed currentThemeStyles state
+  // Removed useEffect for theme updates and MutationObserver
+  // Removed useEffect for applying dynamic styles
 
   return (
     <div 
       ref={actionBarRef}
-      className="rounded-lg p-3"
+      // Main Container: Apply bg-card and text-card-foreground
+      className="rounded-lg p-3 bg-card text-card-foreground flex items-center justify-between w-full"
       id="gemini-enhancer-selection-action-bar-shadcn"
-      style={{ 
-        display: 'flex', 
-        alignItems: 'center', 
-        justifyContent: 'space-between',
-        width: '100%',
-        // backgroundColor and color are now set by the second useEffect via currentThemeStyles state
-      }}
+      // Removed inline style object
     >
       {/* Left side: Select All Checkbox */}
-      <div className="flex items-center mr-4 space-x-2">
+      <div className="flex items-center mr-2 sm:mr-4 space-x-2"> {/* Adjusted margin for smaller screens */}
         <Checkbox
           id="gemini-enhancer-select-all-checkbox-shadcn"
           checked={areAllSelected}
@@ -193,24 +94,20 @@ const SelectionActionBar: React.FC<SelectionActionBarProps> = ({
         />
         <Label 
           htmlFor="gemini-enhancer-select-all-checkbox-shadcn" 
-          className="text-sm font-medium cursor-pointer"
+          // "全选" Label: text-card-foreground is inherited. Count span already has text-muted-foreground.
+          className="text-sm font-medium cursor-pointer" 
         >
           全选 <span className="text-muted-foreground">({selectedCount})</span>
         </Label>
       </div>
 
-      {/* Vertical Separator */}
-      <div className="border-l h-6 self-center mx-1 sm:mx-2"></div>
+      {/* Vertical Separator: Apply border-border */}
+      <div className="border-l border-border h-6 self-center mx-1 sm:mx-2"></div>
 
       {/* Middle: Action buttons */}
       <div 
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          gap: '0.75rem',
-          flexGrow: 1
-        }}
+        className="flex items-center justify-center gap-2 sm:gap-3 flex-grow px-1" // Adjusted gap and added padding
+        // Removed inline style object
       >
         <ShadcnCircularActionButton
           onClick={onCopyMarkdown}
@@ -243,7 +140,7 @@ const SelectionActionBar: React.FC<SelectionActionBarProps> = ({
       </div>
 
       {/* Right side: Close button */}
-      <div className="flex items-center ml-4">
+      <div className="flex items-center ml-2 sm:ml-4"> {/* Adjusted margin for smaller screens */}
         <Button
           variant="ghost"
           size="icon"


### PR DESCRIPTION
The SelectionActionBar component was previously using JavaScript-driven inline styles to manage its appearance, especially for adapting to light and dark themes. This approach led to style conflicts and incorrect rendering, particularly when integrated with a Tailwind CSS project that uses class-based dark mode (`darkMode: "class"`) and CSS variables for theming (common in shadcn/ui setups).

This commit refactors `SelectionActionBar.tsx` to:
- Remove the `currentThemeStyles` state and associated `useEffect` hooks that dynamically applied inline styles for background, text, and border colors.
- Eliminate the `MutationObserver` logic previously used for theme detection.
- Apply Tailwind CSS utility classes directly in the JSX for all theming aspects (e.g., `bg-card`, `text-card-foreground`, `text-muted-foreground`, `border-border`).
- Rely on Tailwind's `dark:` variants and the global `dark` class on the `<html>` element for theme adaptation.

These changes simplify the component's styling logic, ensure it correctly utilizes your project's established Tailwind theming infrastructure, and should resolve the reported style inconsistencies in the multi-select component.