### PR TITLE
Feat: Enhance image handling and multi-select copy

### DIFF
--- a/src/content/actions.ts
+++ b/src/content/actions.ts
@@ -1,7 +1,7 @@
 import { toast } from 'sonner';
 import { GEMINI_SELECTORS } from './selectors';
 import { htmlToMarkdown } from '../core/markdownConverter';
-import { generateImageBlob } from '../core/imageGenerator';
+import { generateImageBlob, generateCombinedImageBlob } from '../core/imageGenerator'; // Added generateCombinedImageBlob
 
 // Helper function to trigger download
 export function triggerDownload(blob: Blob, filename: string) {
@@ -277,4 +277,31 @@ export async function handleDownloadImage(
     console.error('Could not find blockRoot for Download Image.');
     toast.error('无法找到内容块', { description: '无法下载图片，请检查控制台。' });
   }
-} 
+}
+
+// Action: Copy Multiple Messages as a Single Image
+export async function handleCopyMultipleImagesAsSingle(elements: HTMLElement[]): Promise<void> {
+  if (!elements || elements.length === 0) {
+    toast.info("未选择任何消息。");
+    return;
+  }
+
+  console.log(`Action started: Copy ${elements.length} messages as a single image.`);
+  const pageTitle = elements.length > 1 ? `Gemini Chat - ${elements.length} Messages` : `Gemini Chat`;
+
+
+  try {
+    // Pass a pageTitle to the generation function
+    const blob = await generateCombinedImageBlob(elements, { pageTitle }); 
+
+    if (blob) {
+      await navigator.clipboard.write([new ClipboardItem({ 'image/png': blob })]);
+      toast.success(`${elements.length} 条消息已作为单个图片复制到剪贴板。`);
+    } else {
+      toast.error('图片生成失败', { description: '无法生成合并图片。请检查控制台。' });
+    }
+  } catch (error: any) {
+    console.error('Error during combined image copy:', error);
+    toast.error('复制合并图片时出错', { description: error?.message || '未知错误。' });
+  }
+}


### PR DESCRIPTION
This commit introduces two significant improvements to image handling:

1.  **Prefer Full-Sized Google Images:**
    - Updated `src/core/imageGenerator.ts` to modify the `src` URLs of images hosted on `lh3.googleusercontent.com`.
    - The logic attempts to transform these URLs to their full-resolution version (e.g., by ensuring the URL path ends with `=d` and removing/replacing other sizing parameters like `=sXXX`).
    - This aims to improve the quality of captured images when messages contain user-uploaded Google-hosted images.

2.  **Multi-Select Copy as Single Long Image:**
    - Implemented functionality to copy multiple selected messages as a single, continuous ("long") image.
    - Added `generateCombinedImageBlob` to `src/core/imageGenerator.ts`, which takes an array of HTML elements, styles them, and renders them sequentially into one image canvas, including separators.
    - Introduced `handleCopyMultipleImagesAsSingle` in `src/content/actions.ts` to orchestrate this.
    - Modified `src/content/content.tsx` so that the "Copy Image" action in the multi-select bar now calls this new handler, resulting in a single image on the clipboard that combines all selected messages.
    - Individual messages within the combined image are styled for cohesion, appearing as part of one larger card.

These changes address your feedback requesting higher-quality image captures and a more convenient way to export multiple messages as a single image.