### PR TITLE
Fix: Resolve background script loading error

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
     rollupOptions: {
       input: {
         content: resolve(__dirname, 'src/content/content.tsx'),
+        background: resolve(__dirname, 'src/background.ts'), // Added line
         // editor: resolve(__dirname, 'src/editor/main.tsx'), // Example: if editor is a separate page bundle
         // popup: resolve(__dirname, 'src/popup/popup.html'), // Example: if using a popup
       },
@@ -21,6 +22,9 @@ export default defineConfig({
         entryFileNames: (chunkInfo) => {
           if (chunkInfo.name === 'content') {
             return 'js/content.js';
+          }
+          if (chunkInfo.name === 'background') { // Added condition
+            return 'js/background.js';          // Fixed output name
           }
           return 'js/[name]-[hash].js';
         },


### PR DESCRIPTION
Addresses the "Unable to load background script js/background.js" error.

The error was caused by the background script (`src/background.ts`) not being included as an entry point in the Vite build configuration (`vite.config.ts`).

Changes:
- Modified `vite.config.ts` to add `src/background.ts` to `build.rollupOptions.input`.
- Updated `build.rollupOptions.output.entryFileNames` in `vite.config.ts` to ensure the compiled background script is consistently named `js/background.js`, without a hash, matching the path declared in `public/manifest.json`.

These changes ensure the background script is compiled and correctly located, allowing the browser to load it as specified in the manifest.