### PR TITLE
Refactor: Attempt to improve CORS handling for background image fetches

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -12,7 +12,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
       return false; // No async response here
     }
 
-    fetch(imageUrl)
+    fetch(imageUrl, { credentials: 'omit' }) // Added { credentials: 'omit' }
       .then(response => {
         if (!response.ok) {
           throw new Error(`HTTP error! status: ${response.status} for ${imageUrl}`);


### PR DESCRIPTION
Modifies the `fetch` call in `src/background.ts` to include the `{ credentials: 'omit' }` option.

This change is an attempt to address persistent CORS errors encountered when fetching images from `lh3.googleusercontent.com`, even from the background script. By explicitly omitting credentials, the aim is to simplify the request in a way that might satisfy the server's CORS policy.

If this resolves the issue, images will be fetched and displayed. If CORS errors persist for certain images, the existing fallback mechanism (displaying an SVG placeholder) will continue to apply for those images.